### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,5 +1,5 @@
-import { Box, HStack, IconButton, Flex, Image } from '@chakra-ui/react';
-import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons';
+import { Box, HStack, IconButton, Flex, Image, useColorMode } from '@chakra-ui/react';
+import { HamburgerIcon, CloseIcon, MoonIcon, SunIcon } from '@chakra-ui/icons';
 import { useDisclosure } from '@chakra-ui/react';
 import { Link as ScrollLink } from 'react-scroll'; 
 import '../../styles/animation.css';
@@ -7,6 +7,7 @@ import logo from '../../assets/images/logo-nb.png';
 
 const Header = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { colorMode, toggleColorMode } = useColorMode();
   
   return (
 
@@ -19,13 +20,22 @@ const Header = () => {
           </Box>
 
           
-          <IconButton
-            aria-label="Toggle Navigation"
-            icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
-            display={{ md: 'none' }}
-            onClick={isOpen ? onClose : onOpen}
-            colorScheme="whiteAlpha"
-          />
+          <Flex align="center">
+            <IconButton
+              aria-label="Toggle Navigation"
+              icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
+              display={{ md: 'none' }}
+              onClick={isOpen ? onClose : onOpen}
+              colorScheme="whiteAlpha"
+            />
+            <IconButton
+              aria-label="Toggle Theme"
+              icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
+              onClick={toggleColorMode}
+              colorScheme="whiteAlpha"
+              ml={2}
+            />
+          </Flex>
 
           
           <HStack spacing={7} sx={{ marginRight: 100 }} display={{ base: 'none', md: 'flex' }}>
@@ -60,6 +70,12 @@ const Header = () => {
               <ScrollLink to="contact" smooth={true} duration={500} offset={-70} onClick={onClose}>
                 Contact
               </ScrollLink>
+              <IconButton
+                aria-label="Toggle Theme"
+                icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
+                onClick={toggleColorMode}
+                colorScheme="whiteAlpha"
+              />
             </HStack>
           </Box>
         )}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
 import theme from './theme.js';
 import App from './App.jsx';
 import './index.css';
@@ -11,6 +11,7 @@ import './index.css';
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ChakraProvider theme={theme}>
+      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <App />
     </ChakraProvider>
   </StrictMode>,

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,12 @@
 import { extendTheme } from '@chakra-ui/react';
 
+const config = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
+
 const theme = extendTheme({
+  config,
   colors: {
     brand: {
       50: '#fffaf5',


### PR DESCRIPTION
## Summary
- add color mode configuration
- enable ColorModeScript to respect Chakra color settings
- add theme switch IconButton in the header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e95c9f19883239344753b1180528d