### PR TITLE
Enable theme-sensitive background for Accueil

### DIFF
--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -1,4 +1,4 @@
-import { Box, Button, Heading, Text, VStack, Image, Stack, Flex } from '@chakra-ui/react';
+import { Box, Button, Heading, Text, VStack, Image, Stack, Flex, useColorModeValue } from '@chakra-ui/react';
 import { DownloadIcon, EmailIcon } from '@chakra-ui/icons';
 import pdp from '../assets/images/pdp.png';
 import Catalogue from '../assets/catalogue/catalogue.pdf';
@@ -6,6 +6,7 @@ import '../styles/animation.css';
 
 
 const Accueil = () => {
+  const bg = useColorModeValue('white', 'gray.800');
   return (
     <Box
       p={8}
@@ -13,7 +14,7 @@ const Accueil = () => {
       display="flex"
       alignItems="center"
       justifyContent="center"
-      bgColor="white"
+      bgColor={bg}
     >
       
       <Stack


### PR DESCRIPTION
## Summary
- use `useColorModeValue` in `Accueil.jsx` so the background responds to Chakra color mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e9d6d23288323821b926f7cf6da6d