### PR TITLE
Add Inter font across project

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
     <title>Vite + React</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* index.css */
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,6 +7,10 @@ const config = {
 
 const theme = extendTheme({
   config,
+  fonts: {
+    heading: "'Inter', sans-serif",
+    body: "'Inter', sans-serif",
+  },
   colors: {
     brand: {
       50: '#fffaf5',


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts in `index.html`
- extend Chakra theme fonts to use Inter
- update global CSS body font to Inter

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ea464361c83239bc61cf8ebfc7e91