### PR TITLE
Add catalogue download to product cards

### DIFF
--- a/src/pages/Projet.jsx
+++ b/src/pages/Projet.jsx
@@ -6,6 +6,7 @@ import {
   Image,
   useColorModeValue,
 } from "@chakra-ui/react";
+import Catalogue from "../assets/catalogue/catalogue.pdf";
 import { useEffect, useRef } from "react";
 
 const Projet = () => {
@@ -196,7 +197,8 @@ const Projet = () => {
               </Box>
               <Text
                 as="a"
-                href={projet.link}
+                href={Catalogue}
+                download
                 fontSize="sm"
                 color="accent"
                 fontWeight="bold"


### PR DESCRIPTION
## Summary
- let product cards link to the catalogue

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eb62360408323a8c8442710b775c7